### PR TITLE
修改了friction和tension的中文解释

### DIFF
--- a/docs/0.22/animations.md
+++ b/docs/0.22/animations.md
@@ -47,8 +47,8 @@ class Playground extends React.Component {
 这三种动画类型可以用来创建几乎任何你需要的动画曲线，因为它们每一个都可以被自定义：
 
 * `spring`: 基础的单次弹跳物理模型，符合[Origami设计标准](https://facebook.github.io/origami/)
-  * `friction`: 控制“弹跳系数”、夸张系数，默认为7.
-  * `tension`: 控制速度，默认40。
+  * `friction`: 阻力，默认为7.
+  * `tension`: 张力，默认40。
 * `decay`: 以一个初始速度开始并且逐渐减慢停止。
   * `velocity`: 起始速度，必填参数。
   * `deceleration`: 速度衰减比例，默认为0.997。


### PR DESCRIPTION
friction和tension决定了duration，spring动画设置duration选项是没有用的。
前面那种解释看不懂，😓，还特别去官方问了个问题，所以有时候可以不全按照官方翻译么？
