### PR TITLE
修改了第60行import的问题

### DIFF
--- a/docs/0.26/tutorial.md
+++ b/docs/0.26/tutorial.md
@@ -57,9 +57,9 @@ var MOCKED_MOVIES_DATA = [
 我们接下来要展现一个电影，绘制它的标题、年份、以及缩略图(_译注：这个过程我们通常会叫做“渲染/render”，后面我们都会用“渲染”这个词_)。渲染缩略图需要用到Image组件，所以把Image添加到对React的import列表中。
 
 ```javascript
-import React, {
+import {Component} from 'react';
+import {
   AppRegistry,
-  Component,
   Image,
   StyleSheet,
   Text,


### PR DESCRIPTION
您好，我注意到在我的当前版本下 import {component} from 'react-native'会报错，去查看了官方文档，但官方用的是es5写法，地址为https://github.com/facebook/react-native/blob/master/Examples/Movies/MoviesApp.android.js
相关部分代码为
var React = require('react');
var ReactNative = require('react-native');
var {
  AppRegistry,
  BackAndroid,
  Navigator,
  StyleSheet,
  ToolbarAndroid,
  View,
} = ReactNative;
不知是否是版本问题带来的改变？如果确实如此，忘您能做出修正
