### PR TITLE
Update using-navigators.md

### DIFF
--- a/docs/0.30/using-navigators.md
+++ b/docs/0.30/using-navigators.md
@@ -21,12 +21,6 @@ import React, { Component } from 'react';
 import { View, Text } from 'react-native';
 
 export default class MyScene extends Component {
-  getDefaultProps() {
-    return {
-      title: 'MyScene'
-    };
-  }
-
   render() {
     return (
       <View>
@@ -34,6 +28,10 @@ export default class MyScene extends Component {
       </View>
     )
   }
+}
+
+MyScene.defaultProps = {
+  title: 'MyScene'
 }
 ```
 


### PR DESCRIPTION
"getDefaultProps" was deprecated in new version, using static property "defaultProps" to instead of.
